### PR TITLE
Bala/Fix build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
-        "build": "npx ncc build index.js --license licenses.txt --minify"
+        "build": "npx tsc"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
**Changelog**
This PR fixes the build script in package.json file to use typescript compiler instead of vercel ncc.