### PR TITLE
Bala/fix node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,5 +29,5 @@ outputs:
     description: "The captured URL from issue comment"
     
 runs:
-  using: "node18"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
**Changelog**
This PR changes the node version from 18 to 16. Github action doesn't support node version 18.